### PR TITLE
Automated PyPi Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Publish Package
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+
+      - name: Install Twine
+        run: pip install twine
+
+      - name: Build package
+        run: python setup.py sdist
+
+      - name: Publish the package to PyPi
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: twine upload -u __token__ -p $PYPI_TOKEN dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+with open("README.md", "r",  encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name="micropython-ota-updater",
+    version="0.6.1",
+    author="Ronald Dehuysser",
+    description="This micropython module allows for automatic updating of your code on Microcontrollers using github releases.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/rdehuyss/micropython-ota-updater",
+    packages=["app"]
+)


### PR DESCRIPTION
#25 

This will automatically create PyPi updates when new releases are created. The version in `setup.py` has to be updated manually.

To use this, a contributor has to upload a [PyPi token](https://pypi.org/help/#apitoken) as a [project secret](https://github.com/rdehuyss/micropython-ota-updater/settings/secrets/actions) 